### PR TITLE
Fix for displayMode="REPLACE"

### DIFF
--- a/src/xcode/mobbl-core-framework/Controller/MBPageStackController.m
+++ b/src/xcode/mobbl-core-framework/Controller/MBPageStackController.m
@@ -153,7 +153,6 @@
 			// Replace the last page on the stack
 			if([displayMode isEqualToString:@"REPLACE"]) {
 				[nav replaceLastViewController:viewController];
-				return;
 			}
 
 			// Regular navigation to new page


### PR DESCRIPTION
Showing a page from outcome with displayMode="REPLACE" did not activate the corresponding dialog, causing all sorts of problems if it wasn't the current one. This enormous patch fixes this.