### PR TITLE
Feature/migration to arc

### DIFF
--- a/src/xcode/mobbl-core-framework/Controller/MBApplicationFactory.h
+++ b/src/xcode/mobbl-core-framework/Controller/MBApplicationFactory.h
@@ -52,6 +52,12 @@
 +(MBApplicationFactory *) sharedInstance;
 +(void) setSharedInstance:(MBApplicationFactory *) factory;
 
+/** Creates a view controller and a page given the arguments
+ *
+ *  This is a MOBBL internal method, do not override or call directly!
+ */
+- (UIViewController<MBViewControllerProtocol>*)createViewControllerForPageWithDefinition:(MBPageDefinition *)pageDefinition document:(MBDocument *)document rootPath:(NSString *)rootPath;
+
 /**
  *  Given a page name, this returns the corresponding view controller instance.
  *
@@ -73,13 +79,6 @@
 /** override to create custom MBResultListeners */
 -(id<MBResultListener>) createResultListener:(NSString *)listenerClassName;
 -(id<MBContentViewWrapper>) createContentViewWrapper;
-
-/** override this class to create MBPages, UIViewControllers and bind the two together */
--(MBPage *) createPage:(MBPageDefinition *)definition
-              document:(MBDocument*) document
-              rootPath:(NSString*) rootPath
-             viewState:(MBViewState) viewState
-         withMaxBounds:(CGRect) bounds __deprecated_msg("use viewControllerForPageWithName: instead");
 -(UIViewController *) createViewController:(MBPage*) page __deprecated_msg("only use for backwards compatibility with View Builders");
 
 @end

--- a/src/xcode/mobbl-core-framework/Controller/MBApplicationFactory.h
+++ b/src/xcode/mobbl-core-framework/Controller/MBApplicationFactory.h
@@ -52,18 +52,6 @@
 +(MBApplicationFactory *) sharedInstance;
 +(void) setSharedInstance:(MBApplicationFactory *) factory;
 
-/** override this class to create MBPages, UIViewControllers and bind the two together */
--(MBPage *) createPage:(MBPageDefinition *)definition
-			  document:(MBDocument*) document 
-			  rootPath:(NSString*) rootPath 
-			 viewState:(MBViewState) viewState
-         withMaxBounds:(CGRect) bounds __deprecated_msg("use viewControllerForPageWithName: instead");
-
--(MBAlert *)createAlert:(MBAlertDefinition *)definition
-               document:(MBDocument *) document
-               rootPath:(NSString *)rootPath
-               delegate:(id<UIAlertViewDelegate>)alertViewDelegate;
-
 /**
  *  Given a page name, this returns the corresponding view controller instance.
  *
@@ -75,14 +63,23 @@
  */
 - (UIViewController <MBViewControllerProtocol>*)viewControllerForPageWithName:(NSString *)pageName;
 
+-(MBAlert *)createAlert:(MBAlertDefinition *)definition
+               document:(MBDocument *) document
+               rootPath:(NSString *)rootPath
+               delegate:(id<UIAlertViewDelegate>)alertViewDelegate;
 /** override to create MBAction conforming custom actions */
 -(id<MBAction>) createAction:(NSString *)actionClassName;
-
 -(MBDialogController *)createDialogController:(MBDialogDefinition *)definition;
-
 /** override to create custom MBResultListeners */
 -(id<MBResultListener>) createResultListener:(NSString *)listenerClassName;
--(UIViewController *) createViewController:(MBPage*) page;
-
 -(id<MBContentViewWrapper>) createContentViewWrapper;
+
+/** override this class to create MBPages, UIViewControllers and bind the two together */
+-(MBPage *) createPage:(MBPageDefinition *)definition
+              document:(MBDocument*) document
+              rootPath:(NSString*) rootPath
+             viewState:(MBViewState) viewState
+         withMaxBounds:(CGRect) bounds __deprecated_msg("use viewControllerForPageWithName: instead");
+-(UIViewController *) createViewController:(MBPage*) page __deprecated_msg("only use for backwards compatibility with View Builders");
+
 @end

--- a/src/xcode/mobbl-core-framework/Controller/MBApplicationFactory.h
+++ b/src/xcode/mobbl-core-framework/Controller/MBApplicationFactory.h
@@ -31,6 +31,8 @@
 @class MBDocument;
 @class MBDialogController;
 
+@protocol MBViewControllerProtocol;
+
 /** Factory class for creating custom UIViewControllers, MBResultListeners and MBActions 
  * In short there are three steps to using custom code with MOBBL framework:
 
@@ -49,16 +51,30 @@
 /** the shared instance */
 +(MBApplicationFactory *) sharedInstance;
 +(void) setSharedInstance:(MBApplicationFactory *) factory;
+
 /** override this class to create MBPages, UIViewControllers and bind the two together */
--(MBPage *) createPage:(MBPageDefinition *)definition 
+-(MBPage *) createPage:(MBPageDefinition *)definition
 			  document:(MBDocument*) document 
 			  rootPath:(NSString*) rootPath 
 			 viewState:(MBViewState) viewState
-		 withMaxBounds:(CGRect) bounds;
+         withMaxBounds:(CGRect) bounds __deprecated_msg("use viewControllerForPageWithName: instead");
+
 -(MBAlert *)createAlert:(MBAlertDefinition *)definition
                document:(MBDocument *) document
                rootPath:(NSString *)rootPath
                delegate:(id<UIAlertViewDelegate>)alertViewDelegate;
+
+/**
+ *  Given a page name, this returns the corresponding view controller instance.
+ *
+ *  The default implementation for this method returns nil. It should be overwritten by subclass (i.e. a custom ApplicationFactory). After this method is called, the MBPage gets bound to the instance.
+ *
+ *  @param pageName The name of the page
+ *
+ *  @return A view controller instance
+ */
+- (UIViewController <MBViewControllerProtocol>*)viewControllerForPageWithName:(NSString *)pageName;
+
 /** override to create MBAction conforming custom actions */
 -(id<MBAction>) createAction:(NSString *)actionClassName;
 

--- a/src/xcode/mobbl-core-framework/Controller/MBApplicationFactory.m
+++ b/src/xcode/mobbl-core-framework/Controller/MBApplicationFactory.m
@@ -74,7 +74,7 @@ static MBApplicationFactory *_instance = nil;
 	}
 }
 
--(MBPage *) createPage:(MBPageDefinition *)definition 
+-(MBPage *) createPage:(MBPageDefinition *)definition
 			  document:(MBDocument*) document 
 			  rootPath:(NSString*) rootPath 
 			 viewState:(MBViewState) viewState 
@@ -82,6 +82,10 @@ static MBApplicationFactory *_instance = nil;
 	return [[[MBPage alloc] initWithDefinition: definition document: document rootPath:(NSString*) rootPath viewState: viewState withMaxBounds: bounds] autorelease];
 }
 
+- (UIViewController <MBViewControllerProtocol>*)viewControllerForPageWithName:(NSString *)pageName
+{
+    return nil;
+}
 
 -(UIViewController<MBViewControllerProtocol> *) createViewController:(MBPage*) page {
     return [[[MBBasicViewController alloc] init] autorelease];

--- a/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
+++ b/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
@@ -436,17 +436,17 @@ void dispatchOutcomePhase(dispatch_queue_t queue, OutcomeState inState, void (^b
                                                      viewState:viewState
                                                  withMaxBounds:bounds] autorelease];
                     viewController.page = page;
-                    page.viewController = viewController; // For backwards compatibility, this property is deprecated since 29-01-2015
+                    page.viewController = viewController; // For backwards compatibility
                 } else {
                     // For backwards compatibility
                     page = [[MBApplicationController currentInstance].applicationFactory createPage:pageDefinition document:document rootPath:causingOutcome.path viewState:viewState withMaxBounds:bounds];
                     viewController = (UIViewController<MBViewControllerProtocol>*)[[MBApplicationFactory sharedInstance] createViewController:page];
                     viewController.page = page;
-                    page.viewController = viewController; // For backwards compatibility, this property is deprecated since 29-01-2015
-                    viewController.navigationItem.title = page.title;
+                    page.viewController = viewController;
                     [viewController rebuildView];
                 }
                 
+                viewController.navigationItem.title = page.title;
                 page.applicationController = [MBApplicationController currentInstance];
                 page.pageStackName = causingOutcome.pageStackName;
                 

--- a/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
+++ b/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
@@ -419,36 +419,13 @@ void dispatchOutcomePhase(dispatch_queue_t queue, OutcomeState inState, void (^b
             if (pageDefinition != [NSNull null]) {
             
                 [[MBApplicationController currentInstance].viewManager hideActivityIndicator];
-                NSString *displayMode = causingOutcome.displayMode;
-                NSString *transitionStyle = causingOutcome.transitionStyle;
-                MBViewState viewState = [[MBApplicationController currentInstance].viewManager currentViewState];
                 
-                CGRect bounds = [MBApplicationController currentInstance].viewManager.bounds;
+                UIViewController<MBViewControllerProtocol>* viewController = [[MBApplicationController currentInstance].applicationFactory createViewControllerForPageWithDefinition:pageDefinition document:document rootPath:causingOutcome.path];
+                viewController.page.pageStackName = causingOutcome.pageStackName;
                 
-                // The default way since MOBBL 0.0.23 to load a ViewController from a xib. This is ARC compatible, the older createPage: method is not.
-                UIViewController<MBViewControllerProtocol>* viewController = [[MBApplicationController currentInstance].applicationFactory viewControllerForPageWithName:pageDefinition.name]; // hopefully this is auto-released by ARC
-                
-                MBPage *page = nil;
-                
-                if (viewController) {
-                    page = [[[MBPage alloc] initWithDefinition:pageDefinition
-                                                      document:document
-                                                      rootPath:causingOutcome.path
-                                                     viewState:viewState
-                                                 withMaxBounds:bounds] autorelease];
-                    viewController.page = page;
-                    page.viewController = viewController; // For backwards compatibility
-                } else {
-                    // For backwards compatibility with ViewBuilders
-                    page = [[MBApplicationController currentInstance].applicationFactory createPage:pageDefinition document:document rootPath:causingOutcome.path viewState:viewState withMaxBounds:bounds];
-                    viewController = page.viewController;
-                }
-                
-                viewController.navigationItem.title = page.title;
-                page.applicationController = [MBApplicationController currentInstance];
-                page.pageStackName = causingOutcome.pageStackName;
-                
-                [[MBApplicationController currentInstance].viewManager showViewController:(MBBasicViewController *)viewController displayMode:displayMode transitionStyle:transitionStyle];
+                [[MBApplicationController currentInstance].viewManager showViewController:(MBBasicViewController *)viewController
+                                                                              displayMode:causingOutcome.displayMode
+                                                                          transitionStyle:causingOutcome.transitionStyle];
             }
         }
     });

--- a/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
+++ b/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
@@ -440,13 +440,13 @@ void dispatchOutcomePhase(dispatch_queue_t queue, OutcomeState inState, void (^b
                 } else {
                     // For backwards compatibility
                     page = [[MBApplicationController currentInstance].applicationFactory createPage:pageDefinition document:document rootPath:causingOutcome.path viewState:viewState withMaxBounds:bounds];
-                    [page rebuildView];
+                    [page.viewController rebuildView];
                 }
                 
                 page.applicationController = [MBApplicationController currentInstance];
                 page.pageStackName = causingOutcome.pageStackName;
                 
-                [[MBApplicationController currentInstance].viewManager showPage: page displayMode:displayMode transitionStyle:transitionStyle];
+                [[MBApplicationController currentInstance].viewManager showPage:page displayMode:displayMode transitionStyle:transitionStyle];
             }
         }
     });

--- a/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
+++ b/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
@@ -436,11 +436,13 @@ void dispatchOutcomePhase(dispatch_queue_t queue, OutcomeState inState, void (^b
                                                      viewState:viewState
                                                  withMaxBounds:bounds] autorelease];
                     viewController.page = page;
+                    page.viewController = viewController; // For backwards compatibility, this property is deprecated since 29-01-2015
                 } else {
                     // For backwards compatibility
                     page = [[MBApplicationController currentInstance].applicationFactory createPage:pageDefinition document:document rootPath:causingOutcome.path viewState:viewState withMaxBounds:bounds];
                     viewController = (UIViewController<MBViewControllerProtocol>*)[[MBApplicationFactory sharedInstance] createViewController:page];
                     viewController.page = page;
+                    page.viewController = viewController; // For backwards compatibility, this property is deprecated since 29-01-2015
                     viewController.navigationItem.title = page.title;
                     [viewController rebuildView];
                 }

--- a/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
+++ b/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
@@ -436,17 +436,19 @@ void dispatchOutcomePhase(dispatch_queue_t queue, OutcomeState inState, void (^b
                                                      viewState:viewState
                                                  withMaxBounds:bounds] autorelease];
                     viewController.page = page;
-                    page.viewController = viewController;
                 } else {
                     // For backwards compatibility
                     page = [[MBApplicationController currentInstance].applicationFactory createPage:pageDefinition document:document rootPath:causingOutcome.path viewState:viewState withMaxBounds:bounds];
-                    [page.viewController rebuildView];
+                    viewController = (UIViewController<MBViewControllerProtocol>*)[[MBApplicationFactory sharedInstance] createViewController:page];
+                    viewController.page = page;
+                    viewController.navigationItem.title = page.title;
+                    [viewController rebuildView];
                 }
                 
                 page.applicationController = [MBApplicationController currentInstance];
                 page.pageStackName = causingOutcome.pageStackName;
                 
-                [[MBApplicationController currentInstance].viewManager showPage:page displayMode:displayMode transitionStyle:transitionStyle];
+                [[MBApplicationController currentInstance].viewManager showViewController:(MBBasicViewController *)viewController displayMode:displayMode transitionStyle:transitionStyle];
             }
         }
     });

--- a/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
+++ b/src/xcode/mobbl-core-framework/Controller/MBOutcomeManager.m
@@ -425,6 +425,7 @@ void dispatchOutcomePhase(dispatch_queue_t queue, OutcomeState inState, void (^b
                 
                 CGRect bounds = [MBApplicationController currentInstance].viewManager.bounds;
                 
+                // The default way since MOBBL 0.0.23 to load a ViewController from a xib. This is ARC compatible, the older createPage: method is not.
                 UIViewController<MBViewControllerProtocol>* viewController = [[MBApplicationController currentInstance].applicationFactory viewControllerForPageWithName:pageDefinition.name]; // hopefully this is auto-released by ARC
                 
                 MBPage *page = nil;
@@ -438,12 +439,9 @@ void dispatchOutcomePhase(dispatch_queue_t queue, OutcomeState inState, void (^b
                     viewController.page = page;
                     page.viewController = viewController; // For backwards compatibility
                 } else {
-                    // For backwards compatibility
+                    // For backwards compatibility with ViewBuilders
                     page = [[MBApplicationController currentInstance].applicationFactory createPage:pageDefinition document:document rootPath:causingOutcome.path viewState:viewState withMaxBounds:bounds];
-                    viewController = (UIViewController<MBViewControllerProtocol>*)[[MBApplicationFactory sharedInstance] createViewController:page];
-                    viewController.page = page;
-                    page.viewController = viewController;
-                    [viewController rebuildView];
+                    viewController = page.viewController;
                 }
                 
                 viewController.navigationItem.title = page.title;

--- a/src/xcode/mobbl-core-framework/Controller/MBPageStackController.h
+++ b/src/xcode/mobbl-core-framework/Controller/MBPageStackController.h
@@ -30,9 +30,9 @@
 @property (nonatomic, assign) CGRect bounds;
 
 - (id) initWithDefinition:(MBPageStackDefinition *)definition withDialogController:(MBDialogController *)parent;
-- (id) initWithDefinition:(MBPageStackDefinition *)definition page:(MBPage*) page bounds:(CGRect) bounds;
+//- (id) initWithDefinition:(MBPageStackDefinition *)definition page:(MBPage*) page bounds:(CGRect) bounds;
 
-- (void) showPage:(MBPage*) page displayMode:(NSString*) displayMode transitionStyle:(NSString *) style;
+- (void) showViewController:(MBBasicViewController*) page displayMode:(NSString*) displayMode transitionStyle:(NSString *) style;
 - (void) popPageWithTransitionStyle:(NSString *)transitionStyle animated:(BOOL) animated;
 
 

--- a/src/xcode/mobbl-core-framework/Controller/MBPageStackController.m
+++ b/src/xcode/mobbl-core-framework/Controller/MBPageStackController.m
@@ -110,7 +110,7 @@
 	return self;
 }
 
--(id) initWithDefinition:(MBPageStackDefinition*)definition page:(MBPage*) page bounds:(CGRect) bounds {
+/*-(id) initWithDefinition:(MBPageStackDefinition*)definition page:(MBPage*) page bounds:(CGRect) bounds {
 	if(self = [self initWithDefinition:definition]) {
         MBBasicViewController *controller = (MBBasicViewController*)page.viewController;
         controller.pageStackController = self;
@@ -118,24 +118,24 @@
         _bounds = bounds;
 	}
 	return self;
-}
+}*/
 
 
 
--(void)showPage:(MBPage *)page displayMode:(NSString *)displayMode transitionStyle:(NSString *)transitionStyle {
+-(void)showViewController:(MBBasicViewController *)viewController displayMode:(NSString *)displayMode transitionStyle:(NSString *)transitionStyle {
     
-    if(displayMode != nil){
+    [viewController retain];
+    
+    MBPage *page = viewController.page;
+    page.transitionStyle = transitionStyle;
+    UINavigationController *nav = self.navigationController;
+    viewController.pageStackController = self;
+
+    if (displayMode) {
         DLog(@"PageStackController: showPage name=%@ pageStack=%@ mode=%@", page.pageName, _name, displayMode);
 	}
-
-    page.transitionStyle = transitionStyle;
-
-	UINavigationController *nav = self.navigationController;
-	MBBasicViewController *viewController = (MBBasicViewController*)[page.viewController retain];
-
-	viewController.pageStackController = self;
-
-    void (^actuallyShowPage)(void) =^{
+    
+    void (^actuallyShowPage)(void) = ^{
        
 		// Apply transitionStyle for a regular page navigation
 		id<MBTransitionStyle> style = [[[MBApplicationFactory sharedInstance] transitionStyleFactory] transitionForStyle:transitionStyle];
@@ -143,36 +143,25 @@
 
 		[viewController autorelease];
 
-
 		if (self.markedForReset) {
 			self.navigationController.viewControllers = [NSArray arrayWithObject:viewController];
 			self.markedForReset = false;
 		} else {
-
-
 			// Replace the last page on the stack
 			if([displayMode isEqualToString:@"REPLACE"]) {
 				[nav replaceLastViewController:viewController];
 				return;
-			}
-
-			// Regular navigation to new page
-			else {
-                
-				[nav pushViewController:viewController animated:[style animated]];
+			} else {
+                // Regular navigation to new page
+				[nav pushViewController:viewController animated:style.animated];
 			}
 		}
-
 		// This needs to be done after the page (viewController) is visible, because before that we have nothing to set the close button to
-		[self setupCloseButtonForPage:page];
-        
-
+		[self setupCloseButtonForViewController:viewController];
         // page is ready for display; make sure we actually show the dialog
-
-        MBDialogManager * manager = [[[MBApplicationController currentInstance] viewManager] dialogManager];
-        if (![[manager activeDialogName] isEqualToString:[self dialogController].name]) {
-
-            [[[MBViewBuilderFactory sharedInstance] dialogDecoratorFactory] presentDialog:[self dialogController] withTransitionStyle:transitionStyle];
+        MBDialogManager * manager = [MBApplicationController currentInstance].viewManager.dialogManager;
+        if (![manager.activeDialogName isEqualToString:self.dialogController.name]) {
+            [[MBViewBuilderFactory sharedInstance].dialogDecoratorFactory presentDialog:self.dialogController withTransitionStyle:transitionStyle];
         }
         if (![page.pageStackName isEqualToString:manager.activePageStackName]) {
             [manager activatePageStackWithName:page.pageStackName];
@@ -342,11 +331,11 @@
 }
 
 // This needs to be done after the page (viewController) is visible, because before that we have nothing to set the close button to
-- (void)setupCloseButtonForPage:(MBPage *)page {
+- (void)setupCloseButtonForViewController:(MBBasicViewController *)viewController {
     if (self.dialogController.closable) {
         NSString *closeButtonTitle = MBLocalizedString(@"closeButtonTitle");
         UIBarButtonItem *closeButton = [[[UIBarButtonItem alloc] initWithTitle:closeButtonTitle style:UIBarButtonItemStyleBordered target:self action:@selector(closeButtonPressed:)] autorelease];
-        [page.viewController.navigationItem setRightBarButtonItem:closeButton animated:YES];
+        [viewController.navigationItem setRightBarButtonItem:closeButton animated:YES];
     }
 }
 

--- a/src/xcode/mobbl-core-framework/Controller/MBViewManager.h
+++ b/src/xcode/mobbl-core-framework/Controller/MBViewManager.h
@@ -20,6 +20,7 @@
 
 @class MBPage;
 @class MBAlert;
+@class MBBasicViewController;
 
 @interface MBViewManager : NSObject<UITabBarControllerDelegate, UINavigationControllerDelegate, MBDialogManagerDelegate>
 @property (nonatomic, readonly) UIWindow *window;
@@ -29,8 +30,8 @@
 @property (nonatomic, retain) id<MBContentViewWrapper> contentViewWrapper;
 
 - (id) init;
-- (void) showPage:(MBPage*) page displayMode:(NSString*) displayMode;
-- (void) showPage:(MBPage*) page displayMode:(NSString*) displayMode transitionStyle:(NSString *) style;
+- (void)showViewController:(MBBasicViewController*)viewController displayMode:(NSString*)displayMode;
+- (void)showViewController:(MBBasicViewController *)viewController displayMode:(NSString*)displayMode transitionStyle:(NSString *)style;
 - (void) showAlert:(MBAlert *) alert;
 
 /**

--- a/src/xcode/mobbl-core-framework/Controller/MBViewManager.m
+++ b/src/xcode/mobbl-core-framework/Controller/MBViewManager.m
@@ -105,19 +105,19 @@
 	[super dealloc];
 }
 
--(void) showPage:(MBPage*) page displayMode:(NSString*) displayMode {
-    [self showPage:page displayMode:displayMode transitionStyle:nil];
+- (void)showViewController:(MBBasicViewController*)viewController displayMode:(NSString*)displayMode {
+    [self showViewController:viewController displayMode:displayMode transitionStyle:nil];
 }
 
--(void) showPage:(MBPage*) page displayMode:(NSString*) displayMode transitionStyle:(NSString *) transitionStyle  {
+- (void)showViewController:(MBBasicViewController*)viewController displayMode:(NSString*)displayMode transitionStyle:(NSString *)transitionStyle  {
     
-    DLog(@"ViewManager: showPage name=%@ pageStack=%@ mode=%@ type=%i", page.pageName, page.pageStackName, displayMode, page.pageType);
+    MBPage *page = viewController.page;
+    
+    DLog(@"ViewManager: showPage name=%@ pageStack=%@ mode=%@ type=%lu", page.pageName, page.pageStackName, displayMode, (unsigned long)page.pageType);
     
 	if(page.pageType == MBPageTypesErrorPage || [@"POPUP" isEqualToString:displayMode]) {
 		[self showAlertView: page];
-	}
-    else {
-        
+	} else {
         // Backwards compatibility: If the pageStackName of the page is the same as the active one AND there is a displaymode,
         // we can assume that the developer want's to show the dialog in a modal presentation.
         if (displayMode.length > 0 && [page.pageStackName isEqualToString:self.dialogManager.activePageStackName]) {
@@ -151,19 +151,16 @@
             else if([C_DIALOG_DECORATOR_TYPE_MODALPAGESHEET_CLOSABLE isEqualToString:displayMode]) {
                 page.pageStackName = @"PAGESTACK-modalpagesheet-closable";
             }
-        }
-        
-        // The page can get a pageStackName from an outcome but if this is not the case we set the activePageStackName
-        else if (page.pageStackName.length == 0) {
+        } else if (page.pageStackName.length == 0) {
+            // The page can get a pageStackName from an outcome but if this is not the case we set the activePageStackName
             page.pageStackName = self.dialogManager.activePageStackName;
         }
         
         MBDialogController *dialogController = [self.dialogManager dialogForPageStackName:page.pageStackName];
 
-
         // Show page on pageStack; also responsible for activating the dialog
         MBPageStackController *pageStackController = [dialogController pageStackControllerWithName:page.pageStackName];
-        [pageStackController showPage:page displayMode:displayMode transitionStyle:transitionStyle];
+        [pageStackController showViewController:viewController displayMode:displayMode transitionStyle:transitionStyle];
     }
 }
 

--- a/src/xcode/mobbl-core-framework/Controller/Util/MBBasicViewController.h
+++ b/src/xcode/mobbl-core-framework/Controller/Util/MBBasicViewController.h
@@ -24,7 +24,6 @@
 // This class is pushed on UINavigationControllers or other controllers; when released it should trigger
 // the release of MBPage, MBDocument and any other page related stuff.
 
-
 /** Template for custom MBViewController classes. Coupled to exactly one MBPage */
 @interface MBBasicViewController : UIViewController<MBViewControllerProtocol> 
 
@@ -32,11 +31,11 @@
 @property (nonatomic, retain) MBPageStackController *pageStackController;
 
 /** looks up the MBPage associated with this instance and sets the view property with a fresh view hierarchy constructed from the page definition */
-- (void) rebuildView;
-- (void) handleException:(NSException *) exception;
-- (void) showActivityIndicator;
-- (void) hideActivityIndicator;
-- (void) registerOutcomeListener:(id<MBOutcomeListenerProtocol>) listener;
-- (void) unregisterOutcomeListener:(id<MBOutcomeListenerProtocol>) listener;
+- (void)rebuildView;
+- (void)handleException:(NSException *) exception;
+- (void)showActivityIndicator;
+- (void)hideActivityIndicator;
+- (void)registerOutcomeListener:(id<MBOutcomeListenerProtocol>) listener;
+- (void)unregisterOutcomeListener:(id<MBOutcomeListenerProtocol>) listener;
 
 @end

--- a/src/xcode/mobbl-core-framework/Controller/Util/MBBasicViewController.m
+++ b/src/xcode/mobbl-core-framework/Controller/Util/MBBasicViewController.m
@@ -75,8 +75,7 @@
 {
     // Make sure we clear the cache of all related documents:
     [self.page rebuild];
-    
-    if (self.isViewLoaded) {
+    if (!self.isViewLoaded) {
         self.view = [[[UIView alloc] initWithFrame:self.page.maxBounds] autorelease];
     }
     [[MBViewBuilderFactory sharedInstance].pageViewBuilder rebuildPageView:self.page currentView:self.view withMaxBounds:self.page.maxBounds viewState:self.page.viewState];

--- a/src/xcode/mobbl-core-framework/Controller/Util/MBBasicViewController.m
+++ b/src/xcode/mobbl-core-framework/Controller/Util/MBBasicViewController.m
@@ -73,7 +73,10 @@
 
 - (void)rebuildView
 {
-	[self.page rebuildView];	
+    // Make sure we clear the cache of all related documents:
+    [self.page rebuild];
+    self.view = [self.page buildViewWithMaxBounds:self.page.maxBounds forParent:nil viewState:self.page.viewState];
+    [self setupLayoutForIOS7];
 }
 
 - (void)showActivityIndicator

--- a/src/xcode/mobbl-core-framework/Controller/Util/MBBasicViewController.m
+++ b/src/xcode/mobbl-core-framework/Controller/Util/MBBasicViewController.m
@@ -25,10 +25,7 @@
 #import "UIViewController+Rotation.h"
 #import "UIViewController+Layout.h"
 
-@interface MBBasicViewController () {
-    MBPage *_page;
-    MBPageStackController *_pageStackController;
-}
+@interface MBBasicViewController ()
 
 @property (nonatomic, retain) NSMutableArray *outcomeListeners;
 
@@ -36,97 +33,105 @@
 
 @implementation MBBasicViewController
 
-@synthesize page = _page;
-@synthesize pageStackController = _pageStackController;
-
--(id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
-	self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
-    if (self) {
-		_outcomeListeners = [[NSMutableArray array] retain];
+- (NSMutableArray *)outcomeListeners
+{
+    if (!_outcomeListeners) {
+        _outcomeListeners = [[NSMutableArray alloc] init];
     }
-    return self;
+    return _outcomeListeners;
 }
 
 - (void) dealloc
 {
-    [_page release];
-    [_pageStackController release];
-	[_outcomeListeners release];
+    self.page = nil;
+    self.pageStackController = nil;
+    self.outcomeListeners = nil;
     [super dealloc];
 }
 
--(void)viewDidLoad {
+- (void)viewDidLoad
+{
     [super viewDidLoad];
     [self setupBackButton];
-    
     [self setupLayoutForIOS7];
 }
 
--(void)didMoveToParentViewController:(UIViewController *)parent {
+- (void)didMoveToParentViewController:(UIViewController *)parent
+{
 	[super didMoveToParentViewController:parent];
 
 	if (!parent) {
         [self unregisterListenersWithOutcomeHandler];
-        
-	self.outcomeListeners = nil;
-}
+        self.outcomeListeners = nil;
+    }
 }
 
--(void) handleException:(NSException *) exception{
+- (void)handleException:(NSException *) exception
+{
 	[self.page handleException:exception];
 }
 
-- (void) rebuildView {
+- (void)rebuildView
+{
 	[self.page rebuildView];	
 }
 
--(void) showActivityIndicator {
+- (void)showActivityIndicator
+{
 	[[MBApplicationController currentInstance] showActivityIndicator];
 }
 
--(void) hideActivityIndicator {
+- (void)hideActivityIndicator
+{
 	[[MBApplicationController currentInstance] hideActivityIndicator];
 }
 
 // Setup a custom backbutton when a builder is registred
--(void)setupBackButton {
+- (void)setupBackButton
+{
     NSArray *viewControllers = self.navigationController.viewControllers;
-    if ([viewControllers count] > 1) {
-        UIViewController *previousViewController = [viewControllers objectAtIndex:[viewControllers count]-2];
-        UIBarButtonItem *backButton = [[[MBViewBuilderFactory sharedInstance] backButtonBuilderFactory] buildBackButtonWithTitle:previousViewController.navigationItem.title];
+    if (viewControllers.count > 1) {
+        UIViewController *previousViewController = viewControllers[viewControllers.count-2];
+        UIBarButtonItem *backButton = [[MBViewBuilderFactory sharedInstance].backButtonBuilderFactory buildBackButtonWithTitle:previousViewController.navigationItem.title];
         if (backButton) {
             [self.navigationItem setLeftBarButtonItem:backButton animated:NO];
         }
     }
 }
 
-#pragma mark -
-#pragma mark View lifecycle delegate methods
+#pragma mark - View lifecycle delegate methods
 
--(void) viewDidAppear:(BOOL)animated {
+- (void)viewDidAppear:(BOOL)animated
+{
 	for (id childView in [self.view subviews]){
 		if ([childView respondsToSelector:@selector(delegate)]) {
 			id delegate = [childView delegate];
-			if(delegate != self && [delegate respondsToSelector:@selector(viewDidAppear:)]) [delegate viewDidAppear:animated];
+            if (delegate != self && [delegate respondsToSelector:@selector(viewDidAppear:)]) {
+                [delegate viewDidAppear:animated];
+            }
 		}
 	}
 }
 
--(void) viewWillAppear:(BOOL)animated {
+- (void)viewWillAppear:(BOOL)animated
+{
 	// register all outcome listeners with the application controller; this view controller just became
 	// visible, so it is interested in outcomes
     [self registerListenersWithOutcomeHandler];
     
-	for (id childView in [self.view subviews]){
+	for (id childView in self.view.subviews){
 		if ([childView respondsToSelector:@selector(delegate)]) {
 			id delegate = [childView delegate];
-			if(delegate != self && [delegate respondsToSelector:@selector(viewWillAppear:)]) [delegate viewWillAppear:animated];
+            if(delegate != self && [delegate respondsToSelector:@selector(viewWillAppear:)]) {
+                [delegate viewWillAppear:animated];
+            }
 		}
 	}
 }
 
--(void) viewDidDisappear:(BOOL)animated {
-	for (id childView in [self.view subviews]){
+- (void)viewDidDisappear:(BOOL)animated
+{
+	for (id childView in self.view.subviews) {
 		if ([childView respondsToSelector:@selector(delegate)]) {
 			id delegate = [childView delegate];
 			if(delegate != self){
@@ -138,12 +143,13 @@
 	}
 }
 
--(void) viewWillDisappear:(BOOL)animated {
+- (void)viewWillDisappear:(BOOL)animated
+{
 	// remove all outcome listeners from the application controller; this view controller
 	// is going to disappear, so it isn't interested in them anumore
     [self unregisterListenersWithOutcomeHandler];
     
-	for (id childView in [self.view subviews]){
+	for (id childView in self.view.subviews){
 		if ([childView respondsToSelector:@selector(delegate)]) {
 			id delegate = [childView delegate];
 			if(delegate != self ){//&& [delegate respondsToSelector:@selector(viewWillDisappear:)]) {
@@ -153,46 +159,45 @@
 	}
 }
 
-#pragma mark -
-#pragma mark Outcome listeners
+#pragma mark - Outcome listeners
 
-- (void) registerOutcomeListener:(id<MBOutcomeListenerProtocol>) listener {
+- (void)registerOutcomeListener:(id<MBOutcomeListenerProtocol>) listener {
     if (listener == (id<MBOutcomeListenerProtocol>)self) {
         NSLog (@"Don't register self as outcomeListener; this is done automatically!");
         return;
     }
     
-	if(![self.outcomeListeners containsObject:listener]) {
+	if (![self.outcomeListeners containsObject:listener]) {
 		[self.outcomeListeners addObject:listener];
 		[[MBApplicationController currentInstance].outcomeManager registerOutcomeListener:listener];
 	}
 }
 
-- (void) unregisterOutcomeListener:(id<MBOutcomeListenerProtocol>) listener {
+- (void)unregisterOutcomeListener:(id<MBOutcomeListenerProtocol>) listener
+{
 	[[MBApplicationController currentInstance].outcomeManager unregisterOutcomeListener:listener];
-	[self.outcomeListeners removeObject: listener];
+	[self.outcomeListeners removeObject:listener];
 }
 
-
-
-- (void) registerListenersWithOutcomeHandler {
+- (void)registerListenersWithOutcomeHandler
+{
     for(id<MBOutcomeListenerProtocol> lsnr in self.outcomeListeners) {
 		[[MBApplicationController currentInstance].outcomeManager registerOutcomeListener:lsnr];
 	}
     
-    if ([self conformsToProtocol:@protocol(MBOutcomeListenerProtocol) ])
+    if ([self conformsToProtocol:@protocol(MBOutcomeListenerProtocol) ]) {
         [[MBApplicationController currentInstance].outcomeManager registerOutcomeListener:(id<MBOutcomeListenerProtocol>)self];
+    }
 }
 
-- (void) unregisterListenersWithOutcomeHandler {
+- (void)unregisterListenersWithOutcomeHandler {
     for(id<MBOutcomeListenerProtocol> lsnr in self.outcomeListeners) {
 		[[MBApplicationController currentInstance].outcomeManager unregisterOutcomeListener:lsnr];
 	}
     
-    if ([self conformsToProtocol:@protocol(MBOutcomeListenerProtocol) ])
+    if ([self conformsToProtocol:@protocol(MBOutcomeListenerProtocol) ]) {
         [[MBApplicationController currentInstance].outcomeManager unregisterOutcomeListener:(id<MBOutcomeListenerProtocol>)self];
+    }
 }
-
-
 
 @end

--- a/src/xcode/mobbl-core-framework/Controller/Util/MBBasicViewController.m
+++ b/src/xcode/mobbl-core-framework/Controller/Util/MBBasicViewController.m
@@ -75,7 +75,11 @@
 {
     // Make sure we clear the cache of all related documents:
     [self.page rebuild];
-    self.view = [self.page buildViewWithMaxBounds:self.page.maxBounds forParent:nil viewState:self.page.viewState];
+    
+    if (self.isViewLoaded) {
+        self.view = [[[UIView alloc] initWithFrame:self.page.maxBounds] autorelease];
+    }
+    [[MBViewBuilderFactory sharedInstance].pageViewBuilder rebuildPageView:self.page currentView:self.view withMaxBounds:self.page.maxBounds viewState:self.page.viewState];
     [self setupLayoutForIOS7];
 }
 

--- a/src/xcode/mobbl-core-framework/View/Builders/MBViewBuilder.m
+++ b/src/xcode/mobbl-core-framework/View/Builders/MBViewBuilder.m
@@ -56,12 +56,6 @@
         
         if ([child isKindOfClass:[MBPanel class]]) {
             childView = [[MBViewBuilderFactory sharedInstance].panelViewBuilderFactory buildPanelView:(MBPanel *)child forParent:view withMaxBounds:maxChildBounds viewState:viewState];
-        } else if ([child isKindOfClass:[MBForEach class]]) {
-            childView = [[MBViewBuilderFactory sharedInstance].forEachViewBuilder buildForEachView:(MBForEach *)child forParent:view withMaxBounds:maxChildBounds viewState:viewState];
-        } else if ([child isKindOfClass:[MBField class]]) {
-            childView = [[MBViewBuilderFactory sharedInstance].fieldViewBuilderFactory buildFieldView:(MBField *)child forParent:view withMaxBounds:maxChildBounds];
-        } else {
-            childView = [child buildViewWithMaxBounds:maxChildBounds forParent: view viewState: viewState];
         }
             
 		if(childView)

--- a/src/xcode/mobbl-core-framework/View/Builders/MBViewBuilder.m
+++ b/src/xcode/mobbl-core-framework/View/Builders/MBViewBuilder.m
@@ -19,6 +19,9 @@
 #import "MBComponent.h"
 #import "MBStyleHandler.h"
 
+#import "MBPanel.h"
+#import "MBForEach.h"
+
 @implementation MBViewBuilder
 
 -(MBStyleHandler*) styleHandler {
@@ -48,8 +51,19 @@
 		CGRect maxChildBounds = maxBounds;
 		maxChildBounds.size.width -= insetLeft + insetRight;
 		maxChildBounds.size.height -= insetTop + insetBottom;
-		UIView *childView = [child buildViewWithMaxBounds:maxChildBounds forParent: view viewState: viewState];
-		
+        
+        UIView *childView = nil;
+        
+        if ([child isKindOfClass:[MBPanel class]]) {
+            childView = [[MBViewBuilderFactory sharedInstance].panelViewBuilderFactory buildPanelView:(MBPanel *)child forParent:view withMaxBounds:maxChildBounds viewState:viewState];
+        } else if ([child isKindOfClass:[MBForEach class]]) {
+            childView = [[MBViewBuilderFactory sharedInstance].forEachViewBuilder buildForEachView:(MBForEach *)child forParent:view withMaxBounds:maxChildBounds viewState:viewState];
+        } else if ([child isKindOfClass:[MBField class]]) {
+            childView = [[MBViewBuilderFactory sharedInstance].fieldViewBuilderFactory buildFieldView:(MBField *)child forParent:view withMaxBounds:maxChildBounds];
+        } else {
+            childView = [child buildViewWithMaxBounds:maxChildBounds forParent: view viewState: viewState];
+        }
+            
 		if(childView)
 		{
 			xOffset += insetLeft;

--- a/src/xcode/mobbl-core-framework/View/Builders/Page/MBPageViewBuilder.h
+++ b/src/xcode/mobbl-core-framework/View/Builders/Page/MBPageViewBuilder.h
@@ -19,12 +19,8 @@
 
 @class MBPage;
 
-@interface MBPageViewBuilder : MBViewBuilder {
+@interface MBPageViewBuilder : MBViewBuilder
 
-}
-
--(UIView*) buildPageView:(MBPage*) page withMaxBounds:(CGRect) bounds viewState:(MBViewState) viewState;
-
--(void) rebuildPageView:(MBPage*) page currentView:(UIView*) view withMaxBounds:(CGRect) bounds viewState:(MBViewState) viewState;
+- (void)rebuildPageView:(MBPage*)page currentView:(UIView*)view withMaxBounds:(CGRect)bounds viewState:(MBViewState)viewState;
 
 @end

--- a/src/xcode/mobbl-core-framework/View/Builders/Page/MBPageViewBuilder.m
+++ b/src/xcode/mobbl-core-framework/View/Builders/Page/MBPageViewBuilder.m
@@ -22,21 +22,14 @@
 
 @implementation MBPageViewBuilder
 
--(UIView*) buildPageView:(MBPage*) page withMaxBounds:(CGRect) maxBounds viewState:(MBViewState) viewState {
-	UIView *view = [[[UIView alloc] initWithFrame: maxBounds] autorelease];  
-
-    [self rebuildPageView:page currentView:view withMaxBounds:maxBounds viewState:viewState];
-    
-	return view;	
-}
-
 -(void)rebuildPageView:(MBPage *)page currentView:(UIView *)view withMaxBounds:(CGRect)maxBounds viewState:(MBViewState)viewState {
     @autoreleasepool {
 
 
     // create a copy to make sure iterator doesn't break
-    for (UIView *child in [view.subviews.copy autorelease])
-        child.removeFromSuperview;
+    for (UIView *child in [view.subviews.copy autorelease]) {
+        [child removeFromSuperview];
+    }
     
     view.backgroundColor = [UIColor groupTableViewBackgroundColor];
 	

--- a/src/xcode/mobbl-core-framework/View/MBComponent.h
+++ b/src/xcode/mobbl-core-framework/View/MBComponent.h
@@ -48,7 +48,6 @@
 @property (nonatomic, assign) MBDocument *document;
 
 - (id) initWithDefinition:(id)definition document:(MBDocument*) document parent:(MBComponentContainer *) parent;
-- (UIView*) buildViewWithMaxBounds:(CGRect) bounds forParent:(UIView*)parent viewState:(MBViewState) viewState;
 - (void) handleOutcome:(MBOutcome *)outcome;
 - (void) handleOutcome:(NSString *)outcomeName withPathArgument:(NSString*) path;
 - (NSString*) substituteExpressions:(NSString*) expression;

--- a/src/xcode/mobbl-core-framework/View/MBComponent.m
+++ b/src/xcode/mobbl-core-framework/View/MBComponent.m
@@ -65,10 +65,6 @@
   // No children so nothing to build here    
 }
 
--(UIView*) buildViewWithMaxBounds:(CGRect) bounds forParent:(UIView*) parent viewState:(MBViewState) viewState {
-	return nil;	
-}
-
 -(void) handleOutcome:(MBOutcome *)outcomeName {
 	[_parent handleOutcome:outcomeName];
 }

--- a/src/xcode/mobbl-core-framework/View/MBConditionalPage.h
+++ b/src/xcode/mobbl-core-framework/View/MBConditionalPage.h
@@ -16,26 +16,23 @@
 
 #import "MBPage.h"
 
-@interface MBConditionalPage : MBPage {
-	MBPageDefinition *_definitionWhenFalse;
-	MBPageDefinition *_definitionWhenTrue;
-}
+@interface MBConditionalPage : MBPage
 
-@property (nonatomic, retain)MBPageDefinition *definitionWhenFalse;
-@property (nonatomic, retain)MBPageDefinition *definitionWhenTrue;
+@property (nonatomic, retain) MBPageDefinition *definitionWhenFalse;
+@property (nonatomic, retain) MBPageDefinition *definitionWhenTrue;
 
-- (id) initWithDefinitionWhenTrue:(MBPageDefinition*) definitionWhenTrue 
-		  WithDefinitionWhenFalse:(MBPageDefinition*) definitionWhenFalse 
-			   withViewController:(UIViewController<MBViewControllerProtocol>*) viewController 
-						 document:(MBDocument*) document 
-						 rootPath:(NSString*) rootPath
-						viewState:(MBViewState) viewState;
+- (instancetype)initWithDefinitionWhenTrue:(MBPageDefinition*)definitionWhenTrue
+                   WithDefinitionWhenFalse:(MBPageDefinition*)definitionWhenFalse
+                        withViewController:(UIViewController<MBViewControllerProtocol>*)viewController
+                                  document:(MBDocument*)document
+                                  rootPath:(NSString*)rootPath
+                                 viewState:(MBViewState)viewState;
 	
-- (id) initWithDefinitionWhenTrue:(MBPageDefinition*) definitionWhenTrue 
-		   WithDefinitionWhenFalse:(MBPageDefinition*) definitionWhenFalse 
-						  document:(MBDocument*) document 
-						  rootPath:(NSString*) rootPath
-						 viewState:(MBViewState) viewState 
-					 withMaxBounds:(CGRect) bounds;
-	
+- (instancetype)initWithDefinitionWhenTrue:(MBPageDefinition*)definitionWhenTrue
+                   WithDefinitionWhenFalse:(MBPageDefinition*)definitionWhenFalse
+                                  document:(MBDocument*)document
+                                  rootPath:(NSString*)rootPath
+                                 viewState:(MBViewState)viewState
+                             withMaxBounds:(CGRect)bounds;
+
 @end

--- a/src/xcode/mobbl-core-framework/View/MBConditionalPage.m
+++ b/src/xcode/mobbl-core-framework/View/MBConditionalPage.m
@@ -22,57 +22,56 @@
 @synthesize definitionWhenTrue = _definitionWhenTrue;
 @synthesize definitionWhenFalse = _definitionWhenFalse;
 
-- (id) initWithDefinitionWhenTrue:(MBPageDefinition*) definitionWhenTrue 
-		  WithDefinitionWhenFalse:(MBPageDefinition*) definitionWhenFalse 
-			   withViewController:(UIViewController<MBViewControllerProtocol>*) viewController 
-						 document:(MBDocument*) document 
-						 rootPath:(NSString*) rootPath
-						viewState:(MBViewState) viewState {
-	
-	MBPageDefinition *def = ([[MBSession sharedInstance] loggedOn])?definitionWhenTrue:definitionWhenFalse;
-	
-	if(self = [super initWithDefinition:def 
-				  withViewController:viewController 
-							document:document
-							rootPath:rootPath
-							  viewState:viewState]) {
-		self.definitionWhenTrue = definitionWhenTrue;
-		self.definitionWhenFalse = definitionWhenFalse;
-        self.pageName = definitionWhenTrue.name;
-	}
-	return self;
-}
-
-- (id) initWithDefinitionWhenTrue:(MBPageDefinition*) definitionWhenTrue 
-		   WithDefinitionWhenFalse:(MBPageDefinition*) definitionWhenFalse 
-				 document:(MBDocument*) document 
-				 rootPath:(NSString*) rootPath
-				viewState:(MBViewState) viewState 
-			withMaxBounds:(CGRect) bounds {
-
-	MBPageDefinition *def = ([[MBSession sharedInstance] loggedOn])?definitionWhenTrue:definitionWhenFalse;
-	if(self = [super initWithDefinition:def
-							document:document
-							rootPath:rootPath
-						   viewState:viewState
-						  withMaxBounds:bounds])  {
-		self.definitionWhenTrue = definitionWhenTrue;
-		self.definitionWhenFalse = definitionWhenFalse;
-        self.pageName = definitionWhenTrue.name;
-	}
-	return self;
-}
-
-- (void) dealloc
+- (instancetype)initWithDefinitionWhenTrue:(MBPageDefinition*)definitionWhenTrue
+                   WithDefinitionWhenFalse:(MBPageDefinition*)definitionWhenFalse
+                        withViewController:(UIViewController<MBViewControllerProtocol>*)viewController
+                                  document:(MBDocument*)document
+                                  rootPath:(NSString*)rootPath
+                                 viewState:(MBViewState)viewState
 {
-	[_definitionWhenTrue release];
-	[_definitionWhenFalse release];
+	MBPageDefinition *def = ([MBSession sharedInstance].loggedOn) ? definitionWhenTrue
+                                                                  : definitionWhenFalse;
+	
+    self = [super initWithDefinition:def withViewController:viewController document:document rootPath:rootPath viewState:viewState];
+	if (self) {
+		self.definitionWhenTrue = definitionWhenTrue;
+		self.definitionWhenFalse = definitionWhenFalse;
+        self.pageName = definitionWhenTrue.name;
+	}
+	return self;
+}
+
+- (instancetype)initWithDefinitionWhenTrue:(MBPageDefinition*)definitionWhenTrue
+                   WithDefinitionWhenFalse:(MBPageDefinition*)definitionWhenFalse
+                                  document:(MBDocument*)document
+                                  rootPath:(NSString*)rootPath
+                                 viewState:(MBViewState)viewState
+                             withMaxBounds:(CGRect)bounds
+{
+	MBPageDefinition *def = ([MBSession sharedInstance].loggedOn) ? definitionWhenTrue
+                                                                  : definitionWhenFalse;
+    
+    self = [super initWithDefinition:def document:document rootPath:rootPath viewState:viewState withMaxBounds:bounds];
+    if (self)  {
+		self.definitionWhenTrue = definitionWhenTrue;
+		self.definitionWhenFalse = definitionWhenFalse;
+        self.pageName = definitionWhenTrue.name;
+	}
+	return self;
+}
+
+- (void)dealloc
+{
+    self.definitionWhenTrue = nil;
+    self.definitionWhenFalse = nil;
 	[super dealloc];
 }
 
--(void) rebuildView {
-	self.definition = ([[MBSession sharedInstance] loggedOn])?self.definitionWhenTrue:self.definitionWhenFalse;
-	[super rebuildView];
+- (void)rebuild
+{
+	self.definition = ([MBSession sharedInstance].loggedOn) ? self.definitionWhenTrue
+                                                            : self.definitionWhenFalse;
+	[super rebuild];
 }
 
 @end

--- a/src/xcode/mobbl-core-framework/View/MBField.m
+++ b/src/xcode/mobbl-core-framework/View/MBField.m
@@ -209,10 +209,6 @@
 	return _attributeDefinition;
 }
 
--(UIView*) buildViewWithMaxBounds:(CGRect) bounds forParent:(UIView*) parent  viewState:(MBViewState) viewState {
-	return [[[MBViewBuilderFactory sharedInstance] fieldViewBuilderFactory] buildFieldView: self forParent: parent withMaxBounds: bounds];
-}
-
 // This will translate any expression that are part of the path to their actual values
 - (void) translatePath {
 	_translatedPath =  [[self substituteExpressions:[self absoluteDataPath]] retain];

--- a/src/xcode/mobbl-core-framework/View/MBForEach.m
+++ b/src/xcode/mobbl-core-framework/View/MBForEach.m
@@ -92,10 +92,6 @@
 	[row setParent:self];
 }
 
--(UIView*) buildViewWithMaxBounds:(CGRect) bounds forParent:(UIView*) parent viewState:(MBViewState) viewState {
-	return [[[MBViewBuilderFactory sharedInstance] forEachViewBuilder] buildForEachView: self forParent:parent withMaxBounds: bounds viewState: viewState];
-}
-
 -(BOOL) resignFirstResponder {
 	BOOL result = FALSE;
 	for(MBForEachItem *row in self.rows) result |= [row resignFirstResponder];

--- a/src/xcode/mobbl-core-framework/View/MBForEachItem.m
+++ b/src/xcode/mobbl-core-framework/View/MBForEachItem.m
@@ -34,12 +34,6 @@
 	return [self substituteExpressions: path];
 }
 
--(UIView*) buildViewWithMaxBounds:(CGRect) bounds forParent:(UIView*) parent viewState:(MBViewState) viewState {
-	return nil;
-    // TODO: Return the correct builder type
-    //return [[[MBViewBuilderFactory sharedInstance] rowViewBuilderFactory] buildRowView: self forParent: parent withMaxBounds: bounds viewState: viewState];
-}
-
 -(NSString*) evaluateExpression:(NSString*) variableName {
 	MBForEachDefinition *eachDef = (MBForEachDefinition*) [[self parent] definition];
 	MBVariableDefinition *varDef = [eachDef variable: variableName];

--- a/src/xcode/mobbl-core-framework/View/MBPage.h
+++ b/src/xcode/mobbl-core-framework/View/MBPage.h
@@ -46,8 +46,8 @@
 @property (nonatomic, assign) MBViewState viewState;
 
 // Deprecated properties
-@property (nonatomic, assign) UIViewController<MBViewControllerProtocol> *viewController __deprecated;
-@property (nonatomic, retain) NSMutableArray *childViewControllers __deprecated; // Contains the ViewControllers of potential child views (like UITableViewControllers)
+@property (nonatomic, assign) UIViewController<MBViewControllerProtocol> *viewController __deprecated; // Deprecated since 29-01-2015
+@property (nonatomic, retain) NSMutableArray *childViewControllers __deprecated; // Contains the ViewControllers of potential child views (like UITableViewControllers). Deprecated since 29-01-2015.
 
 // for initialising a generic page:
 - (instancetype)initWithDefinition:(id)definition
@@ -68,13 +68,13 @@
 
 - (MBDocumentDiff*)diffDocument:(MBDocument*)other;
 
-// Deprecated
+// Deprecated since 29-01-2015
 // for loading interface builder files:
 - (instancetype)initWithDefinition:(MBPageDefinition*) definition
                 withViewController:(UIViewController<MBViewControllerProtocol>*) viewController
                           document:(MBDocument*) document
                           rootPath:(NSString*) rootPath
-                         viewState:(MBViewState) viewState __deprecated;
+                         viewState:(MBViewState) viewState __deprecated; 
 - (void)unregisterAllViewControllers __deprecated;
 - (id)viewControllerOfType:(Class) clazz __deprecated;
 

--- a/src/xcode/mobbl-core-framework/View/MBPage.h
+++ b/src/xcode/mobbl-core-framework/View/MBPage.h
@@ -39,7 +39,6 @@
 @property (nonatomic, retain) NSString *dialogName;
 @property (nonatomic, retain) MBDocument *document;
 @property (nonatomic, assign) MBApplicationController *applicationController;
-@property (nonatomic, assign) UIViewController <MBViewControllerProtocol>*viewController;
 @property (nonatomic, retain) NSMutableArray *childViewControllers; // Contains the ViewControllers of potential child views (like UITableViewControllers)
 @property (nonatomic, retain) MBDocumentDiff *documentDiff;
 @property (nonatomic, assign) MBPageType pageType;
@@ -68,7 +67,6 @@
 - (void)handleException:(NSException *)exception;
 
 // View
-- (UIView*)view;
 - (void)rebuild;
 - (MBViewState)currentViewState;
 - (void)unregisterAllViewControllers;

--- a/src/xcode/mobbl-core-framework/View/MBPage.h
+++ b/src/xcode/mobbl-core-framework/View/MBPage.h
@@ -46,18 +46,18 @@
 @property (nonatomic, retain) NSString *transitionStyle;
 
 // for loading interface builder files:
-- (id) initWithDefinition:(MBPageDefinition*) definition
-	   withViewController:(UIViewController<MBViewControllerProtocol>*) viewController
-				 document:(MBDocument*) document
-				 rootPath:(NSString*) rootPath
-				viewState:(MBViewState) viewState;
+- (instancetype)initWithDefinition:(MBPageDefinition*) definition
+                withViewController:(UIViewController<MBViewControllerProtocol>*) viewController
+                          document:(MBDocument*) document
+                          rootPath:(NSString*) rootPath
+                         viewState:(MBViewState) viewState;
 
 // for initialising a generic page:
-- (id) initWithDefinition:(id)definition
-				 document:(MBDocument*) document
-				 rootPath:(NSString*) rootPath
-				viewState:(MBViewState) viewState
-			withMaxBounds:(CGRect) bounds;
+- (instancetype) initWithDefinition:(id)definition
+                           document:(MBDocument*) document
+                           rootPath:(NSString*) rootPath
+                          viewState:(MBViewState) viewState
+                      withMaxBounds:(CGRect) bounds;
 
 // Outcome handling
 - (void) handleOutcome:(NSString *)outcomeName;

--- a/src/xcode/mobbl-core-framework/View/MBPage.h
+++ b/src/xcode/mobbl-core-framework/View/MBPage.h
@@ -45,6 +45,9 @@
 @property (nonatomic, assign) MBPageType pageType;
 @property (nonatomic, retain) NSString *transitionStyle;
 
+@property (nonatomic, assign) CGRect maxBounds;
+@property (nonatomic, assign) MBViewState viewState;
+
 // for loading interface builder files:
 - (instancetype)initWithDefinition:(MBPageDefinition*) definition
                 withViewController:(UIViewController<MBViewControllerProtocol>*) viewController
@@ -53,26 +56,25 @@
                          viewState:(MBViewState) viewState;
 
 // for initialising a generic page:
-- (instancetype) initWithDefinition:(id)definition
-                           document:(MBDocument*) document
-                           rootPath:(NSString*) rootPath
-                          viewState:(MBViewState) viewState
-                      withMaxBounds:(CGRect) bounds;
+- (instancetype)initWithDefinition:(id)definition
+                          document:(MBDocument*) document
+                          rootPath:(NSString*) rootPath
+                         viewState:(MBViewState) viewState
+                     withMaxBounds:(CGRect) bounds;
 
 // Outcome handling
-- (void) handleOutcome:(NSString *)outcomeName;
-- (void) handleOutcome:(NSString *)outcomeName withPathArgument:(NSString*) path;
-- (void) handleException:(NSException *)exception;
+- (void)handleOutcome:(NSString *)outcomeName;
+- (void)handleOutcome:(NSString *)outcomeName withPathArgument:(NSString*) path;
+- (void)handleException:(NSException *)exception;
 
 // View
-- (UIView*) view;
+- (UIView*)view;
 - (void)rebuild;
-- (void) rebuildView;
-- (MBViewState) currentViewState;
-- (void) unregisterAllViewControllers;
-- (id) viewControllerOfType:(Class) clazz;
+- (MBViewState)currentViewState;
+- (void)unregisterAllViewControllers;
+- (id)viewControllerOfType:(Class) clazz;
 - (void)hideKeyboard:(id)sender;
 
-- (MBDocumentDiff*) diffDocument:(MBDocument*) other;
+- (MBDocumentDiff*)diffDocument:(MBDocument*)other;
 
 @end

--- a/src/xcode/mobbl-core-framework/View/MBPage.h
+++ b/src/xcode/mobbl-core-framework/View/MBPage.h
@@ -49,12 +49,20 @@
 @property (nonatomic, assign) UIViewController<MBViewControllerProtocol> *viewController __deprecated; // Deprecated since 29-01-2015
 @property (nonatomic, retain) NSMutableArray *childViewControllers __deprecated; // Contains the ViewControllers of potential child views (like UITableViewControllers). Deprecated since 29-01-2015.
 
+// for loading interface builder files:
+- (instancetype)initWithDefinition:(MBPageDefinition*) definition
+                withViewController:(UIViewController<MBViewControllerProtocol>*) viewController
+                          document:(MBDocument*) document
+                          rootPath:(NSString*) rootPath
+                         viewState:(MBViewState) viewState;
+
+// Deprecated since 29-01-2015
 // for initialising a generic page:
 - (instancetype)initWithDefinition:(id)definition
                           document:(MBDocument*)document
                           rootPath:(NSString*)rootPath
                          viewState:(MBViewState)viewState
-                     withMaxBounds:(CGRect)bounds;
+                     withMaxBounds:(CGRect)bounds __deprecated;
 
 // Outcome handling
 - (void)handleOutcome:(NSString *)outcomeName;
@@ -68,13 +76,6 @@
 
 - (MBDocumentDiff*)diffDocument:(MBDocument*)other;
 
-// Deprecated since 29-01-2015
-// for loading interface builder files:
-- (instancetype)initWithDefinition:(MBPageDefinition*) definition
-                withViewController:(UIViewController<MBViewControllerProtocol>*) viewController
-                          document:(MBDocument*) document
-                          rootPath:(NSString*) rootPath
-                         viewState:(MBViewState) viewState __deprecated; 
 - (void)unregisterAllViewControllers __deprecated;
 - (id)viewControllerOfType:(Class) clazz __deprecated;
 

--- a/src/xcode/mobbl-core-framework/View/MBPage.h
+++ b/src/xcode/mobbl-core-framework/View/MBPage.h
@@ -39,27 +39,22 @@
 @property (nonatomic, retain) NSString *dialogName;
 @property (nonatomic, retain) MBDocument *document;
 @property (nonatomic, assign) MBApplicationController *applicationController;
-@property (nonatomic, retain) NSMutableArray *childViewControllers; // Contains the ViewControllers of potential child views (like UITableViewControllers)
 @property (nonatomic, retain) MBDocumentDiff *documentDiff;
 @property (nonatomic, assign) MBPageType pageType;
 @property (nonatomic, retain) NSString *transitionStyle;
-
 @property (nonatomic, assign) CGRect maxBounds;
 @property (nonatomic, assign) MBViewState viewState;
 
-// for loading interface builder files:
-- (instancetype)initWithDefinition:(MBPageDefinition*) definition
-                withViewController:(UIViewController<MBViewControllerProtocol>*) viewController
-                          document:(MBDocument*) document
-                          rootPath:(NSString*) rootPath
-                         viewState:(MBViewState) viewState;
+// Deprecated properties
+@property (nonatomic, assign) UIViewController<MBViewControllerProtocol> *viewController __deprecated;
+@property (nonatomic, retain) NSMutableArray *childViewControllers __deprecated; // Contains the ViewControllers of potential child views (like UITableViewControllers)
 
 // for initialising a generic page:
 - (instancetype)initWithDefinition:(id)definition
-                          document:(MBDocument*) document
-                          rootPath:(NSString*) rootPath
-                         viewState:(MBViewState) viewState
-                     withMaxBounds:(CGRect) bounds;
+                          document:(MBDocument*)document
+                          rootPath:(NSString*)rootPath
+                         viewState:(MBViewState)viewState
+                     withMaxBounds:(CGRect)bounds;
 
 // Outcome handling
 - (void)handleOutcome:(NSString *)outcomeName;
@@ -69,10 +64,18 @@
 // View
 - (void)rebuild;
 - (MBViewState)currentViewState;
-- (void)unregisterAllViewControllers;
-- (id)viewControllerOfType:(Class) clazz;
 - (void)hideKeyboard:(id)sender;
 
 - (MBDocumentDiff*)diffDocument:(MBDocument*)other;
+
+// Deprecated
+// for loading interface builder files:
+- (instancetype)initWithDefinition:(MBPageDefinition*) definition
+                withViewController:(UIViewController<MBViewControllerProtocol>*) viewController
+                          document:(MBDocument*) document
+                          rootPath:(NSString*) rootPath
+                         viewState:(MBViewState) viewState __deprecated;
+- (void)unregisterAllViewControllers __deprecated;
+- (id)viewControllerOfType:(Class) clazz __deprecated;
 
 @end

--- a/src/xcode/mobbl-core-framework/View/MBPage.m
+++ b/src/xcode/mobbl-core-framework/View/MBPage.m
@@ -93,7 +93,9 @@
         self.pageType = definition.pageType;
 		self.viewState = viewState;
         self.maxBounds = [UIScreen mainScreen].applicationFrame;
+        
         self.viewController = viewController;
+        self.viewController.page = self;
         
 		// Ok; now we can build the children:
         for(MBDefinition *def in definition.children) {
@@ -114,6 +116,10 @@
     self = [self initWithDefinition:definition withViewController:nil document:document rootPath:rootPath viewState:viewState];
     if (self) {
         self.maxBounds = bounds;
+        self.viewController = (UIViewController<MBViewControllerProtocol>*)[[MBApplicationFactory sharedInstance] createViewController:self];
+        self.viewController.navigationItem.title = [self title];
+        self.viewController.page = self;
+        [self.viewController rebuildView];
         //[self rebuildView];
     }
 	return self;

--- a/src/xcode/mobbl-core-framework/View/MBPage.m
+++ b/src/xcode/mobbl-core-framework/View/MBPage.m
@@ -93,7 +93,8 @@
         self.pageType = definition.pageType;
 		self.viewState = viewState;
         self.maxBounds = [UIScreen mainScreen].applicationFrame;
-
+        self.viewController = viewController;
+        
 		// Ok; now we can build the children:
         for(MBDefinition *def in definition.children) {
             if([def isPreConditionValid:document currentPath:self.absoluteDataPath]) {
@@ -212,12 +213,6 @@
         [_rootPath retain];
     }
 }
-
-
-/*- (UIView*)view
-{
-    return self.viewController.view;
-}*/
 
 - (void)unregisterAllViewControllers
 {

--- a/src/xcode/mobbl-core-framework/View/MBPage.m
+++ b/src/xcode/mobbl-core-framework/View/MBPage.m
@@ -33,106 +33,90 @@
 
 #import "UIViewController+Layout.h"
 
-@interface MBPage () {
-    // Public properties
-	NSString *_pageName;
-	NSString *_rootPath;
-	NSString *_dialogName;
-    MBDocument *_document;
-	MBApplicationController *_applicationController;
-    UIViewController<MBViewControllerProtocol> *_viewController;
-    NSMutableArray *_childViewControllers;
-	MBDocumentDiff *_documentDiff;
-    MBPageType _pageType;
-    NSString *_transitionStyle;
-    
-	NSMutableDictionary *_valueChangedListeners;
-	CGRect _maxBounds;
-	MBViewState _viewState;
-}
+@interface MBPage ()
+
 @property (nonatomic, retain) NSMutableDictionary *valueChangedListeners;
 @property (nonatomic, assign) CGRect maxBounds;
 @property (nonatomic, assign) MBViewState viewState;
+
 @end
 
 @implementation MBPage
 
-// Public properties
-@synthesize pageName = _pageName;
-@synthesize rootPath = _rootPath;
-@synthesize pageStackName = _pageStackName;
-@synthesize dialogName = _dialogName;
 @synthesize document = _document;
-@synthesize applicationController = _applicationController;
-@synthesize viewController = _viewController;
-@synthesize childViewControllers = _childViewControllers;
-@synthesize documentDiff = _documentDiff;
-@synthesize pageType = _pageType;
-@synthesize transitionStyle = _transitionStyle;
 
-//Private properties
-@synthesize valueChangedListeners = _valueChangedListeners;
-@synthesize maxBounds = _maxBounds;
-@synthesize viewState = _viewState;
-
-
--(void) dealloc {
-	// Public properties
-	[_pageName release];
-	[_rootPath release];
-    [_pageStackName release];
-    [_dialogName release];
-    [_document release];
-    //[_controller release]; // Do not release the ApplicationController because it is not retained!
-    //[_viewController release]; // Do not release the ViewController because it is not retained!
-    [_childViewControllers release];
-	[_documentDiff release];
-    [_transitionStyle release];
-    
-    // Private properties
-	[_valueChangedListeners release];
-	[super dealloc];
+- (NSMutableDictionary *)valueChangedListeners
+{
+    if (!_valueChangedListeners) {
+        _valueChangedListeners = [NSMutableDictionary dictionary];
+    }
+    return _valueChangedListeners;
 }
 
+- (NSMutableArray *)childViewControllers
+{
+    if (!_childViewControllers) {
+        _childViewControllers = [[NSMutableArray alloc] init];
+    }
+    return _childViewControllers;
+}
 
+-(void) dealloc
+{
+	// Public properties
+    self.pageName = nil;
+    self.rootPath = nil;
+    self.pageStackName = nil;
+    self.dialogName = nil;
+    self.childViewControllers = nil;
+    self.documentDiff = nil;
+    self.transitionStyle = nil;
+    self.valueChangedListeners = nil;
+    
+    [_document release];
+    [super dealloc];
+}
 
--(id) initWithDefinition:(MBPageDefinition*) definition 
-      withViewController:(UIViewController<MBViewControllerProtocol>*) viewController 
-                document:(MBDocument*) document 
-                rootPath:(NSString*) rootPath 
-			   viewState:(MBViewState) viewState {
-
+- (instancetype)initWithDefinition:(MBPageDefinition*) definition
+                withViewController:(UIViewController<MBViewControllerProtocol>*) viewController
+                          document:(MBDocument*) document
+                          rootPath:(NSString*) rootPath
+                         viewState:(MBViewState) viewState
+{
     // Make sure that the Panel does not start building the view based on the children OF THIS PAGE because that is too early
     // The children need the additional information that is set after the constructor of super. So pass buildViewStructure: FALSE
     // and build the children ourselves here
-	if(self = [super initWithDefinition:definition document: document parent: nil buildViewStructure: FALSE]) {
+    self = [super initWithDefinition:definition document:document parent:nil buildViewStructure:NO];
+	if (self) {
         self.definition = definition;
         self.rootPath = rootPath;
         self.pageName = definition.name;
 		self.document = document;
-		self.valueChangedListeners = [NSMutableDictionary dictionary];
         self.pageType = definition.pageType;
 		self.viewState = viewState;
         self.maxBounds = [UIScreen mainScreen].applicationFrame;
 
 		self.viewController = viewController;
-		[self.viewController  setPage: self];
+		self.viewController.page = self;
 		
 		// Ok; now we can build the children:
         for(MBDefinition *def in definition.children) {
-			if([def isPreConditionValid:document currentPath:[self absoluteDataPath]]) [self addChild: [MBComponentFactory componentFromDefinition: def document: document parent: self]];
+            if([def isPreConditionValid:document currentPath:self.absoluteDataPath]) {
+                [self addChild:[MBComponentFactory componentFromDefinition:def document:document parent:self]];
+            }
 		}
 	}
 	return self;
 }
 
--(id) initWithDefinition:(MBPageDefinition*)definition 
-				document:(MBDocument*) document 
-				rootPath:(NSString*) rootPath
-			   viewState:(MBViewState) viewState 
-		   withMaxBounds:(CGRect) bounds {
-	
-    if(self = [self initWithDefinition:definition withViewController:nil document:document rootPath:rootPath viewState:viewState]) {
+- (instancetype)initWithDefinition:(MBPageDefinition*)definition
+                          document:(MBDocument*) document
+                          rootPath:(NSString*) rootPath
+                         viewState:(MBViewState) viewState
+                     withMaxBounds:(CGRect) bounds
+{
+    self = [self initWithDefinition:definition withViewController:nil document:document rootPath:rootPath viewState:viewState];
+    if(self) {
         self.maxBounds = bounds;
         self.viewController = (UIViewController<MBViewControllerProtocol>*)[[MBApplicationFactory sharedInstance]createViewController:self];
         self.viewController.navigationItem.title = [self title];
@@ -145,98 +129,110 @@
 }
 
 
--(void) rebuild {
+- (void)rebuild
+{
 	[self.document clearAllCaches];
 	[super rebuild];
 }
 
--(void) rebuildView {
+- (void)rebuildView
+{
 	// Make sure we clear the cache of all related documents:
 	[self rebuild];
-    self.viewController.view = [self buildViewWithMaxBounds: self.maxBounds forParent:nil viewState: self.viewState];
+    self.viewController.view = [self buildViewWithMaxBounds:self.maxBounds forParent:nil viewState:self.viewState];
     [self.viewController setupLayoutForIOS7];
 }
 
 // This is a method required by component so any component can find the page
--(MBPage*) page {
+- (MBPage*)page
+{
 	return self;
 }
 
--(void) hideKeyboard:(id) sender {
+- (void)hideKeyboard:(id)sender
+{
 	[self resignFirstResponder];
 }
 
--(UIView*) buildViewWithMaxBounds:(CGRect) bounds forParent:(UIView*) parent  viewState:(MBViewState) viewState {
-    if ([self.viewController isViewLoaded])
+- (UIView*)buildViewWithMaxBounds:(CGRect)bounds forParent:(UIView*)parent viewState:(MBViewState)viewState
+{
+    if (self.viewController.isViewLoaded)
     {
-        [[[MBViewBuilderFactory sharedInstance] pageViewBuilder] rebuildPageView: self currentView:self.viewController.view withMaxBounds: bounds viewState: viewState];
+        [[MBViewBuilderFactory sharedInstance].pageViewBuilder rebuildPageView:self currentView:self.viewController.view withMaxBounds:bounds viewState:viewState];
         return self.viewController.view;
     }
     else
     {
-        return [[[MBViewBuilderFactory sharedInstance] pageViewBuilder] buildPageView: self withMaxBounds: bounds viewState: viewState];
+        return [[MBViewBuilderFactory sharedInstance].pageViewBuilder buildPageView:self withMaxBounds:bounds viewState:viewState];
     }
 }
 
--(void) handleException:(NSException *)exception {
-	MBOutcome *outcome = [[MBOutcome alloc] initWithOutcomeName: self.pageName document:self.document];
+- (void)handleException:(NSException *)exception
+{
+	MBOutcome *outcome = [[MBOutcome alloc] initWithOutcomeName:self.pageName document:self.document];
 	[self.applicationController handleException:exception outcome:outcome];
 	[outcome release];
 }
 
--(void) handleOutcome:(NSString *)outcomeName {
-	[self handleOutcome:outcomeName withPathArgument: nil];
+- (void)handleOutcome:(NSString *)outcomeName
+{
+	[self handleOutcome:outcomeName withPathArgument:nil];
 }
 
--(void) handleOutcome:(NSString *)outcomeName withPathArgument:(NSString*) path {
+- (void)handleOutcome:(NSString *)outcomeName withPathArgument:(NSString*)path
+{
 	MBOutcome *outcome = [[MBOutcome alloc] init];
 	outcome.originName = self.pageName;
 	outcome.outcomeName = outcomeName;
-	outcome.document = [self document];
-    outcome.pageStackName = [self pageStackName];
+	outcome.document = self.document;
+    outcome.pageStackName = self.pageStackName;
 	outcome.path = path;
 
 	[self.applicationController handleOutcome:outcome];
 	[outcome release];
 }
 
--(NSString *) componentDataPath {
+- (NSString *)componentDataPath
+{
 	return [self rootPath];
 }
 
--(NSString *) description {
-    return [NSString stringWithFormat:@"<%@: %p; pageID: %@>", [self class], self, self.pageName];
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p; pageID: %@>", [MBPage class], self, self.pageName];
 }
 
--(void) setRootPath:(NSString *) path {
-    
+- (void)setRootPath:(NSString *)path
+{
 	BOOL ignorePath = FALSE;
+    
+    if (!path) {
+        path = @"";
+    } else if (![path hasSuffix:@"/"]) {
+        path = [NSString stringWithFormat:@"%@/", path];
+    }
 	
-	if(path == nil) path = @"";
-    else if(![path hasSuffix:@"/"]) path = [NSString stringWithFormat:@"%@/", path];
-	
-	if([path length]>0) {
-		MBPageDefinition* pd = (MBPageDefinition*) [self definition];
-		NSString *stripped = [[path stripCharacters:@"[]0123456789"] normalizedPath];
+	if (path.length > 0) {
+		MBPageDefinition* pd = (MBPageDefinition*)self.definition;
+		NSString *stripped = [path stripCharacters:@"[]0123456789"].normalizedPath;
 		
 		// If the last character is not a slash (/), add one.
 		if (![stripped hasSuffix:@"/"]) {
 			stripped = [NSString stringWithFormat:@"%@/", stripped];
 		}
 		
-		
-		
 		NSString *mustBe = pd.rootPath;
-		if(mustBe == nil || [mustBe isEqualToString:@""]) mustBe = @"/";
+        if (!mustBe || [mustBe isEqualToString:@""]) {
+            mustBe = @"/";
+        }
         
-		if(![stripped isEqualToString:mustBe]) {
-			if([mustBe isEqualToString:@"/"]) {
+		if (![stripped isEqualToString:mustBe]) {
+			if ([mustBe isEqualToString:@"/"]) {
 				WLog(@"Ignoring path %@ because the document definition used root path %@", stripped, mustBe);
 				ignorePath = TRUE;
-			}
-			else {
-				NSString *msg = [NSString stringWithFormat:@"Invalid root path %@->%@; does not conform to defined document root path %@ for page %@", path, stripped, mustBe, [self name]];
-				@throw [NSException exceptionWithName:@"InvalidPath" reason: msg userInfo:nil];
+			} else {
+				NSString *msg = [NSString stringWithFormat:@"Invalid root path %@->%@; does not conform to defined document root path %@ for page %@", path, stripped, mustBe, self.name];
+				@throw [NSException exceptionWithName:@"InvalidPath" reason:msg userInfo:nil];
 			}
 		}
 	}
@@ -249,20 +245,25 @@
 }
 
 
--(UIView*) view {
+- (UIView*)view
+{
     return self.viewController.view;
 }
 
-- (void) unregisterAllViewControllers {
+- (void)unregisterAllViewControllers
+{
 	self.childViewControllers = nil;
 }
 
-- (void) registerViewController:(UIViewController*) controller {
-    if(self.childViewControllers == nil) self.childViewControllers = [[NSMutableArray new] autorelease];
-    if(![self.childViewControllers containsObject: controller]) [self.childViewControllers addObject:controller];
+- (void)registerViewController:(UIViewController*)controller
+{
+    if (![self.childViewControllers containsObject:controller]) {
+        [self.childViewControllers addObject:controller];
+    }
 }
 
--(id) viewControllerOfType:(Class) clazz {
+- (id)viewControllerOfType:(Class)clazz
+{
 	if(self.childViewControllers != nil) {
 		for (UIViewController *ctrl in self.childViewControllers) {
 			if ([ctrl isKindOfClass: clazz]) return ctrl;
@@ -270,7 +271,9 @@
 	}
 	return nil;
 }
-- (NSString *) asXmlWithLevel:(int)level {
+
+- (NSString *)asXmlWithLevel:(int)level
+{
 	NSMutableString *result = [NSMutableString stringWithFormat: @"%*s<MBPage%@%@%@%@>\n", level, "",
 							   [self attributeAsXml:@"pageName" withValue:self.name],
 							   [self attributeAsXml:@"rootPath" withValue:self.rootPath],
@@ -284,80 +287,78 @@
 	return result;
 }
 
--(MBDocumentDiff*) diffDocument:(MBDocument*) other {
-    
-	MBDocumentDiff *diff = [[MBDocumentDiff alloc]initWithDocumentA:self.document andDocumentB: other];
+- (MBDocumentDiff*)diffDocument:(MBDocument*)other
+{
+	MBDocumentDiff *diff = [[MBDocumentDiff alloc] initWithDocumentA:self.document andDocumentB:other];
 	self.documentDiff = diff;
 	[diff release];
-	
 	return self.documentDiff;
 }
 
--(NSMutableArray*) listenersForPath:(NSString*) path {
-	if(![path hasPrefix:@"/"]) path = [NSString stringWithFormat:@"/%@", path];
+- (NSMutableArray*)listenersForPath:(NSString*)path
+{
+    if(![path hasPrefix:@"/"]) {
+        path = [NSString stringWithFormat:@"/%@", path];
+    }
 	
-	path = [path normalizedPath];
+	path = path.normalizedPath;
 	NSMutableArray *lsnrList = [self.valueChangedListeners valueForKey:path];
-	if(lsnrList == nil) {
+	if (!lsnrList) {
 		lsnrList = [NSMutableArray array];
 		[self.valueChangedListeners setObject:lsnrList forKey:path];
 	}
 	return lsnrList;
 }
 
-- (void) registerValueChangeListener:(id<MBValueChangeListenerProtocol>) listener forPath:(NSString*) path {
+- (void)registerValueChangeListener:(id<MBValueChangeListenerProtocol>)listener forPath:(NSString*)path
+{
 	// Check that the path is valid by reading the value:
-	[[self document] valueForPath:path];
-	
-	NSMutableArray *lsnrList = [self listenersForPath: path];
+	[self.document valueForPath:path];
+	NSMutableArray *lsnrList = [self listenersForPath:path];
 	[lsnrList addObject:listener];
 }
 
-- (void) unregisterValueChangeListener:(id<MBValueChangeListenerProtocol>) listener forPath:(NSString*) path {
+- (void)unregisterValueChangeListener:(id<MBValueChangeListenerProtocol>)listener forPath:(NSString*)path
+{
 	// Check that the path is valid by reading the value:
-	[[self document] valueForPath:path];
-	
+	[self.document valueForPath:path];
 	NSMutableArray *lsnrList = [self listenersForPath: path];
 	[lsnrList removeObject:listener];
 }
 
-- (void) unregisterValueChangeListener:(id<MBValueChangeListenerProtocol>) listener {
+- (void)unregisterValueChangeListener:(id<MBValueChangeListenerProtocol>)listener
+{
 	// Check that the path is valid by reading the value:
-	
-	for(NSMutableArray *list in [self.valueChangedListeners allValues]) [list removeObject:listener];
+    for(NSMutableArray *list in self.valueChangedListeners.allValues) {
+        [list removeObject:listener];
+    }
 }
 
-- (BOOL) notifyValueWillChange:(NSString*) value originalValue:(NSString*) originalValue forPath:(NSString*) path {
+- (BOOL)notifyValueWillChange:(NSString*)value originalValue:(NSString*)originalValue forPath:(NSString*)path
+{
 	BOOL result = TRUE;
-	NSMutableArray *lsnrList = [self listenersForPath: path];
+	NSMutableArray *lsnrList = [self listenersForPath:path];
 	for(id lsnr in lsnrList) {
-		if([lsnr respondsToSelector:@selector(valueWillChange:originalValue:forPath:)])
+        if ([lsnr respondsToSelector:@selector(valueWillChange:originalValue:forPath:)]) {
 			result &= [lsnr valueWillChange:value originalValue:originalValue forPath:path];
+        }
 	}
 	return result;
 }
 
-- (void) notifyValueChanged:(NSString*) value originalValue:(NSString*) originalValue forPath:(NSString*) path {
-	NSMutableArray *lsnrList = [self listenersForPath: path];
+- (void)notifyValueChanged:(NSString*)value originalValue:(NSString*)originalValue forPath:(NSString*)path
+{
+	NSMutableArray *lsnrList = [self listenersForPath:path];
 	for(id lsnr in lsnrList) {
-		if([lsnr respondsToSelector:@selector(valueChanged:originalValue:forPath:)])
+        if ([lsnr respondsToSelector:@selector(valueChanged:originalValue:forPath:)]) {
 			[lsnr valueChanged:value originalValue:originalValue forPath:path];
+        }
 	}
 }
 
-- (MBViewState) currentViewState {
+- (MBViewState)currentViewState
+{
 	return self.viewState;
-}
-
-- (NSString *)pageStackName {
-    return _pageStackName;
-}
-
-- (void)setPageStackName:(NSString *)pageStackName {
-    if (_pageStackName != pageStackName) {
-        [_pageStackName release];
-        _pageStackName = [pageStackName retain];
-    }
 }
 
 @end

--- a/src/xcode/mobbl-core-framework/View/MBPage.m
+++ b/src/xcode/mobbl-core-framework/View/MBPage.m
@@ -137,7 +137,8 @@
         self.viewController = (UIViewController<MBViewControllerProtocol>*)[[MBApplicationFactory sharedInstance]createViewController:self];
         self.viewController.navigationItem.title = [self title];
         [self.viewController setPage:self];
-        [self rebuildView];
+        
+        //[self rebuildView];
     }
     
 	return self;

--- a/src/xcode/mobbl-core-framework/View/MBPage.m
+++ b/src/xcode/mobbl-core-framework/View/MBPage.m
@@ -94,9 +94,6 @@
 		self.viewState = viewState;
         self.maxBounds = [UIScreen mainScreen].applicationFrame;
 
-		self.viewController = viewController;
-		self.viewController.page = self;
-		
 		// Ok; now we can build the children:
         for(MBDefinition *def in definition.children) {
             if([def isPreConditionValid:document currentPath:self.absoluteDataPath]) {
@@ -116,9 +113,6 @@
     self = [self initWithDefinition:definition withViewController:nil document:document rootPath:rootPath viewState:viewState];
     if (self) {
         self.maxBounds = bounds;
-        self.viewController = (UIViewController<MBViewControllerProtocol>*)[[MBApplicationFactory sharedInstance]createViewController:self];
-        self.viewController.navigationItem.title = [self title];
-        self.viewController.page = self;
         //[self rebuildView];
     }
 	return self;
@@ -220,10 +214,10 @@
 }
 
 
-- (UIView*)view
+/*- (UIView*)view
 {
     return self.viewController.view;
-}
+}*/
 
 - (void)unregisterAllViewControllers
 {

--- a/src/xcode/mobbl-core-framework/View/MBPage.m
+++ b/src/xcode/mobbl-core-framework/View/MBPage.m
@@ -36,8 +36,6 @@
 @interface MBPage ()
 
 @property (nonatomic, retain) NSMutableDictionary *valueChangedListeners;
-@property (nonatomic, assign) CGRect maxBounds;
-@property (nonatomic, assign) MBViewState viewState;
 
 @end
 
@@ -116,15 +114,13 @@
                      withMaxBounds:(CGRect) bounds
 {
     self = [self initWithDefinition:definition withViewController:nil document:document rootPath:rootPath viewState:viewState];
-    if(self) {
+    if (self) {
         self.maxBounds = bounds;
         self.viewController = (UIViewController<MBViewControllerProtocol>*)[[MBApplicationFactory sharedInstance]createViewController:self];
         self.viewController.navigationItem.title = [self title];
-        [self.viewController setPage:self];
-        
+        self.viewController.page = self;
         //[self rebuildView];
     }
-    
 	return self;
 }
 
@@ -133,14 +129,6 @@
 {
 	[self.document clearAllCaches];
 	[super rebuild];
-}
-
-- (void)rebuildView
-{
-	// Make sure we clear the cache of all related documents:
-	[self rebuild];
-    self.viewController.view = [self buildViewWithMaxBounds:self.maxBounds forParent:nil viewState:self.viewState];
-    [self.viewController setupLayoutForIOS7];
 }
 
 // This is a method required by component so any component can find the page
@@ -156,15 +144,11 @@
 
 - (UIView*)buildViewWithMaxBounds:(CGRect)bounds forParent:(UIView*)parent viewState:(MBViewState)viewState
 {
-    if (self.viewController.isViewLoaded)
-    {
-        [[MBViewBuilderFactory sharedInstance].pageViewBuilder rebuildPageView:self currentView:self.viewController.view withMaxBounds:bounds viewState:viewState];
-        return self.viewController.view;
+    if (self.viewController.isViewLoaded) {
+        self.viewController.view = [[[UIView alloc] initWithFrame:bounds] autorelease];
     }
-    else
-    {
-        return [[MBViewBuilderFactory sharedInstance].pageViewBuilder buildPageView:self withMaxBounds:bounds viewState:viewState];
-    }
+    [[MBViewBuilderFactory sharedInstance].pageViewBuilder rebuildPageView:self currentView:self.viewController.view withMaxBounds:bounds viewState:viewState];
+    return self.viewController.view;
 }
 
 - (void)handleException:(NSException *)exception

--- a/src/xcode/mobbl-core-framework/View/MBPage.m
+++ b/src/xcode/mobbl-core-framework/View/MBPage.m
@@ -46,7 +46,7 @@
 - (NSMutableDictionary *)valueChangedListeners
 {
     if (!_valueChangedListeners) {
-        _valueChangedListeners = [NSMutableDictionary dictionary];
+        _valueChangedListeners = [[NSMutableDictionary alloc] init];
     }
     return _valueChangedListeners;
 }
@@ -140,15 +140,6 @@
 - (void)hideKeyboard:(id)sender
 {
 	[self resignFirstResponder];
-}
-
-- (UIView*)buildViewWithMaxBounds:(CGRect)bounds forParent:(UIView*)parent viewState:(MBViewState)viewState
-{
-    if (self.viewController.isViewLoaded) {
-        self.viewController.view = [[[UIView alloc] initWithFrame:bounds] autorelease];
-    }
-    [[MBViewBuilderFactory sharedInstance].pageViewBuilder rebuildPageView:self currentView:self.viewController.view withMaxBounds:bounds viewState:viewState];
-    return self.viewController.view;
 }
 
 - (void)handleException:(NSException *)exception

--- a/src/xcode/mobbl-core-framework/View/MBPage.m
+++ b/src/xcode/mobbl-core-framework/View/MBPage.m
@@ -117,7 +117,7 @@
     if (self) {
         self.maxBounds = bounds;
         self.viewController = (UIViewController<MBViewControllerProtocol>*)[[MBApplicationFactory sharedInstance] createViewController:self];
-        self.viewController.navigationItem.title = [self title];
+        self.viewController.navigationItem.title = self.title;
         self.viewController.page = self;
         [self.viewController rebuildView];
         //[self rebuildView];

--- a/src/xcode/mobbl-core-framework/View/MBPanel.m
+++ b/src/xcode/mobbl-core-framework/View/MBPanel.m
@@ -116,10 +116,6 @@
 	return MBLocalizedStringWithoutLoggingWarnings(result);
 }
 
--(UIView*) buildViewWithMaxBounds:(CGRect) bounds forParent:(UIView*) parent  viewState:(MBViewState) viewState {
-	return [[[MBViewBuilderFactory sharedInstance] panelViewBuilderFactory] buildPanelView: self forParent:parent withMaxBounds: bounds viewState: viewState];
-}
-
 - (NSString *) asXmlWithLevel:(int)level {
 	NSMutableString *result = [NSMutableString stringWithFormat: @"%*s<MBPanel%@%@%@%@%@%@%@>\n", level, "",
 							   [self attributeAsXml:@"type" withValue:_type],

--- a/src/xcode/mobbl-core-framework/View/Tables/MBTableViewController.h
+++ b/src/xcode/mobbl-core-framework/View/Tables/MBTableViewController.h
@@ -28,7 +28,7 @@
  * Extends a convenience class in UIKit to create a TableView / List type screen based on an MBPanel of type "LIST" in a MBPage definition.
  * The page definition is generally stored in the file config.xmlx or in a file referenced by config.xmlx using the <Include ... /> directive.
  */
-@interface MBTableViewController : UITableViewController <UIWebViewDelegate, UIGestureRecognizerDelegate, MBPickerControllerDelegate, MBViewControllerProtocol, MBFontChangeListenerProtocol>{
+@interface MBTableViewController : UITableViewController <UIWebViewDelegate, UIGestureRecognizerDelegate, MBPickerControllerDelegate, MBViewControllerProtocol/*, MBFontChangeListenerProtocol*/>{
     
     NSMutableArray *_sections;
     NSMutableDictionary *_webViews;

--- a/src/xcode/mobbl-core-framework/View/Tables/MBTableViewController.h
+++ b/src/xcode/mobbl-core-framework/View/Tables/MBTableViewController.h
@@ -28,7 +28,7 @@
  * Extends a convenience class in UIKit to create a TableView / List type screen based on an MBPanel of type "LIST" in a MBPage definition.
  * The page definition is generally stored in the file config.xmlx or in a file referenced by config.xmlx using the <Include ... /> directive.
  */
-@interface MBTableViewController : UITableViewController <UIWebViewDelegate, UIGestureRecognizerDelegate, MBPickerControllerDelegate, MBViewControllerProtocol/*, MBFontChangeListenerProtocol*/>{
+@interface MBTableViewController : UITableViewController <UIWebViewDelegate, UIGestureRecognizerDelegate, MBPickerControllerDelegate, MBViewControllerProtocol, MBFontChangeListenerProtocol>{
     
     NSMutableArray *_sections;
     NSMutableDictionary *_webViews;

--- a/src/xcode/mobbl-core-framework/View/Tables/MBTableViewController.m
+++ b/src/xcode/mobbl-core-framework/View/Tables/MBTableViewController.m
@@ -43,7 +43,7 @@
 #define C_CELL_Y_MARGIN 4
 
 // TODO: Get the font size and name from the styleHandler
-@interface MBTableViewController()/*<MBFontCustomizerDelegate>*/
+@interface MBTableViewController()<MBFontCustomizerDelegate>
 
 @property (nonatomic, retain) NSMutableDictionary *rowsByIndexPath;
 @property (nonatomic, assign) NSInteger fontCustomizerFontSizeDifference;
@@ -334,7 +334,7 @@
 }
 
 
-/*#pragma mark -
+#pragma mark -
 #pragma mark MBFontChangeListenerProtocol methods
 
 -(void)showFontCustomizer:(BOOL)show {
@@ -373,7 +373,7 @@
         }
         [self.tableView reloadData];
     }
-}*/
+}
 
 
 #pragma mark -

--- a/src/xcode/mobbl-core-framework/View/Tables/MBTableViewController.m
+++ b/src/xcode/mobbl-core-framework/View/Tables/MBTableViewController.m
@@ -91,7 +91,7 @@
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    //[self showFontCustomizer:self.zoomable];
+    [self showFontCustomizer:self.zoomable];
 }
 
 -(NSInteger) numberOfSectionsInTableView:(UITableView *)tableView{

--- a/src/xcode/mobbl-core-framework/View/Tables/MBTableViewController.m
+++ b/src/xcode/mobbl-core-framework/View/Tables/MBTableViewController.m
@@ -43,7 +43,7 @@
 #define C_CELL_Y_MARGIN 4
 
 // TODO: Get the font size and name from the styleHandler
-@interface MBTableViewController()<MBFontCustomizerDelegate>
+@interface MBTableViewController()/*<MBFontCustomizerDelegate>*/
 
 @property (nonatomic, retain) NSMutableDictionary *rowsByIndexPath;
 @property (nonatomic, assign) NSInteger fontCustomizerFontSizeDifference;
@@ -91,7 +91,7 @@
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    [self showFontCustomizer:self.zoomable];
+    //[self showFontCustomizer:self.zoomable];
 }
 
 -(NSInteger) numberOfSectionsInTableView:(UITableView *)tableView{
@@ -334,7 +334,7 @@
 }
 
 
-#pragma mark -
+/*#pragma mark -
 #pragma mark MBFontChangeListenerProtocol methods
 
 -(void)showFontCustomizer:(BOOL)show {
@@ -373,7 +373,7 @@
         }
         [self.tableView reloadData];
     }
-}
+}*/
 
 
 #pragma mark -


### PR DESCRIPTION
- Added functionality to support ARC in a backwards compatible way
- Made the view controller the unit of displaying instead of MBPage
- Removed buildView methods on MBComponent subclasses
- Deprecated viewController related methods and properties from MBComponent subclasses
- Tested for backwards compatibility with a real MOBBL project